### PR TITLE
Proxy events to the service, and handle WS

### DIFF
--- a/cmd/flux-adapter/main.go
+++ b/cmd/flux-adapter/main.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	_ "net/http/pprof"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -13,6 +15,8 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
 	"github.com/spf13/pflag"
 
 	//	api "github.com/weaveworks/flux/api"
@@ -28,6 +32,7 @@ type adapterConfig struct {
 	connectURL  string
 	apiURL      string
 	bearerToken string
+	listen      string
 }
 
 var version = "unversioned"
@@ -41,6 +46,7 @@ func main() {
 	fs.StringVar(&conf.connectURL, "connect", "https://cloud.weave.works/api/flux", "Connect to Weave Cloud at this base address, including the path /api/flux")
 	fs.StringVar(&conf.apiURL, "api", "http://localhost:3030/api/flux", "Connect to the flux API (i.e., fluxd) at this base URL, including if necessary the path /api/flux")
 	fs.StringVar(&conf.bearerToken, "token", "", "use this bearer token to authenticate with Weave Cloud")
+	fs.StringVar(&conf.listen, "listen", "localhost:3039", "address on which to listen for fluxd connections")
 
 	err := fs.Parse(os.Args[1:])
 
@@ -78,6 +84,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	router := mux.NewRouter()
+	transport.UpstreamRoutes(router)
+	shutdown := make(chan struct{})
+	handler, err := installHandlers(router, conf, logger, shutdown)
+	if err != nil {
+		logger.Log("err", err)
+		os.Exit(1)
+	}
+
 	errc := make(chan error)
 	go func() {
 		c := make(chan os.Signal, 1)
@@ -85,7 +100,14 @@ func main() {
 		errc <- fmt.Errorf("%s", <-c)
 	}()
 
+	go func() {
+		m := http.DefaultServeMux
+		m.Handle("/", handler)
+		errc <- http.ListenAndServe(conf.listen, m)
+	}()
+
 	logger.Log("msg", "shutting down", "err", <-errc)
+	close(shutdown)
 	up.Close()
 }
 
@@ -117,4 +139,74 @@ func (r *upstreamRelay) Version(ctx context.Context) (string, error) {
 
 func (r *upstreamRelay) NotifyChange(ctx context.Context, change apiV9.Change) error {
 	return notImplemented
+}
+
+// This handler will serve the endpoint for events, and send them on
+// to Weave Cloud. It includes the daemon RPC (websocket connection)
+// endpoints for now, so that the fluxd argument `--connect` can be
+// used to target this adapter. This will be removed eventually.
+
+func installHandlers(r *mux.Router, config adapterConfig, logger log.Logger, shutdown chan struct{}) (*mux.Router, error) {
+	serviceURL, err := url.Parse(config.connectURL)
+	if err != nil {
+		return nil, err
+	}
+	proxy := httputil.NewSingleHostReverseProxy(serviceURL)
+	director := proxy.Director
+	proxy.Director = func(r *http.Request) {
+		director(r)
+		fluxclient.Token(config.bearerToken).Set(r)
+	}
+
+	r.Get(transport.LogEvent).HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		logger.Log("info", "proxying", "url", req.URL.String())
+		proxy.ServeHTTP(res, req)
+	})
+
+	upgrader := websocket.Upgrader{}
+
+	for _, endpoint := range []string{
+		transport.RegisterDaemonV6,
+		transport.RegisterDaemonV7,
+		transport.RegisterDaemonV8,
+		transport.RegisterDaemonV9,
+		transport.RegisterDaemonV10,
+		transport.RegisterDaemonV11,
+	} {
+		r.Get(endpoint).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			logger.Log("msg", "websocket connection", "addr", r.RemoteAddr)
+			ws, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprintf(w, err.Error())
+				return
+			}
+
+			// it's necessary to pull frames through the websocket, so
+			// that controls get processed by the connection. (A close
+			// from the other side will trigger an error in
+			// NextReader.)
+			wsErr := make(chan error, 1)
+			go func() {
+				for {
+					if _, _, err = ws.NextReader(); err != nil {
+						wsErr <- err
+						break
+					}
+				}
+			}()
+
+			select {
+			case <-shutdown:
+				logger.Log("msg", "closing websocket", "reason", "shutting down")
+			case err = <-wsErr:
+				logger.Log("msg", "closing websocket", "reason", "errored", "err", err.Error())
+			}
+
+			ws.Close()
+			logger.Log("msg", "closed websocket", "addr", r.RemoteAddr)
+		})
+	}
+
+	return r, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.12
 
 require (
 	github.com/go-kit/kit v0.8.0
+	github.com/gorilla/mux v1.7.1
+	github.com/gorilla/websocket v1.4.0
 	github.com/spf13/pflag v1.0.3
 	github.com/weaveworks/flux v0.0.0-20190626150815-6f552720900b
 )


### PR DESCRIPTION
This adds slightly rough implementations for
 - proxying events to the upstream service (Weave Cloud)
 - accepting websocket connections

The latter is to support present fluxd, which will attempt to connect
a websocket to the service given in the arg `--connect`, as well as
send events to it. Since the websocket is intended for RPC _from_ the
service, all the implementation needs to do is pull packets through it
so pings are ponged.

This is enough for the fluxd+adapter to look like an operational Deploy agent in Weave Cloud.