### PR TITLE
Use a local name in Makefile for the image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,9 @@ jobs:
       GOPATH: /home/circleci/go
       PATH: /bin:/usr/bin:/usr/local/go/bin:/home/circleci/go/bin
       # this image name must match what the Makefile builds
-      IMAGE: docker.io/weaveworks/flux-adapter
-      PRERELEASE: docker.io/weaveworks/flux-adapter-prerelease
+      BUILD_IMAGE: local/flux-adapter:${CIRCLE_SHA1}
+      GA_IMAGE: docker.io/weaveworks/flux-adapter
+      PRERELEASE_IMAGE: docker.io/weaveworks/flux-adapter-prerelease
     steps:
       - checkout
       - run:
@@ -43,7 +44,8 @@ jobs:
             - go-modules-
 
 #      - run: make test TEST_FLAGS="-race -tags integration -timeout 60s"
-      - run: make all
+      # Give the image a name particular to this build
+      - run: make image IMAGE_NAME="${BUILD_IMAGE}"
       - save_cache:
           key: go-build-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -58,8 +60,8 @@ jobs:
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
               TAG="${CIRCLE_BRANCH}-$(git rev-parse --short HEAD)"
               echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
-              docker tag "$IMAGE" "$PRERELEASE:$TAG"
-              docker push "$PRERELEASE:$TAG"
+              docker tag "$BUILD_IMAGE" "$PRERELEASE_IMAGE:$TAG"
+              docker push "$PRERELEASE_IMAGE:$TAG"
             fi
       - deploy:
           name: Maybe push release image
@@ -67,8 +69,8 @@ jobs:
             if echo "${CIRCLE_TAG}" | grep -Eq "^[0-9]+(\.[0-9]+)*(-[a-z]+)?$"; then
               TAG="${CIRCLE_TAG}"
               echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
-              docker tag "docker.io/weaveworks/flux-adapter" "docker.io/weaveworks/flux-adapter:$TAG"
-              docker push "docker.io/weaveworks/flux-adapter:$TAG"
+              docker tag "$BUILD_IMAGE" "$GA_IMAGE:$TAG"
+              docker push "$GA_IMAGE:$TAG"
             fi
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
-.PHONY: all clean FORCE
+.PHONY: all clean image FORCE
 
 all: build/flux-adapter build/image.tar
 
 clean:
 	rm -rf ./build
 
+image: build/image.tar
+
 TINI_VERSION:=v0.18.0
 TINI_CHECKSUM:=eadb9d6e2dc960655481d78a92d2c8bc021861045987ccd3e27c7eae5af0cf33
 
-VERSION := $(shell git describe --tags --dirty --always)
+VERSION:=$(shell git describe --tags --dirty --always)
 VCS_REF:=$(shell git rev-parse HEAD)
 BUILD_DATE:=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 STATIC=-tags netgo -ldflags '-extldflags "-static"'
+
+IMAGE_NAME ?= "local/flux-adapter"
 
 build/flux-adapter: FORCE
 	GOOS=linux GOARCH=amd64 go build -o "$@" $(STATIC) -ldflags "-X main.version=$(VERSION)" ./cmd/flux-adapter
@@ -27,8 +31,8 @@ build/tini_$(TINI_VERSION):
 build/image.tar: Dockerfile build/flux-adapter build/tini
 	mkdir -p ./build/docker/
 	cp $^ ./build/docker/
-	docker build -t docker.io/weaveworks/flux-adapter -t docker.io/weaveworks/flux-adapter:$(VCS_REF) \
+	docker build -t $(IMAGE_NAME) \
 		--build-arg VCS_REF="$(VCS_REF)" \
 		--build-arg BUILD_DATE="$(BUILD_DATE)" \
 		-f build/docker/Dockerfile ./build/docker/
-	docker save docker.io/weaveworks/flux-adapter > "$@"
+	docker save $(IMAGE_NAME) > "$@"


### PR DESCRIPTION
To be able to be clearer about which image is which, use a dummy,
local name for the image being built in the Makefile. That can be
referred to directly (e.g., when running in minikube), or retagged to
be pushed somewhere.

The CircleCI script does the latter, firstly naming the image after
the commit SHA1, then retagging it and pushing that to DockerHub.