### PR TITLE
Add basic proxying Docker image

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,6 @@
+FROM varnish:6.2
+
+CMD ["varnishd", "-F", "-a", "127.0.0.1:3033", "-T", "none", "-f", "/etc/varnish/default.vcl"]
+
+COPY default.vcl /etc/varnish/default.vcl
+

--- a/proxy/default.vcl
+++ b/proxy/default.vcl
@@ -1,0 +1,17 @@
+vcl 4.1;
+
+backend default {
+  .host = "127.0.0.1";
+  .port = "3030";
+}
+
+sub vcl_recv {
+  if (req.url ~ "^/api/flux") {
+    set req.backend_hint = default;
+  }
+}
+
+sub vcl_backend_response {
+  set beresp.ttl = 5s;
+  set beresp.grace = 30s;
+}


### PR DESCRIPTION
As a web UI, Weave Cloud will send through the same request as many
times as there are tabs open, but much of the time the request (and
response) are exactly the same.

To coalesce them, we can put a caching proxy between the adapter and
the flux daemon. This commit adds an image build that uses Varnish for
this proxy, with a very minimal configuration.