### PR TITLE
Add minimal nsswitch.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENTRYPOINT [ "/sbin/tini", "--", "/usr/local/bin/flux-adapter" ]
 
 # Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
 # This resolves the conflict between:
-# * fluxd using netgo for static compilation. netgo reads nsswitch.conf to mimic glibc,
+# * flux-adapter using netgo for static compilation. netgo reads nsswitch.conf to mimic glibc,
 #   defaulting to prioritize DNS queries over /etc/hosts if nsswitch.conf is missing:
 #   https://github.com/golang/go/issues/22846
 # * Alpine not including a nsswitch.conf file. Since Alpine doesn't use glibc

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,16 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
 
 ENTRYPOINT [ "/sbin/tini", "--", "/usr/local/bin/flux-adapter" ]
 
+# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
+# This resolves the conflict between:
+# * fluxd using netgo for static compilation. netgo reads nsswitch.conf to mimic glibc,
+#   defaulting to prioritize DNS queries over /etc/hosts if nsswitch.conf is missing:
+#   https://github.com/golang/go/issues/22846
+# * Alpine not including a nsswitch.conf file. Since Alpine doesn't use glibc
+#   (it uses musl), maintainers argue that the need of nsswitch.conf is a Go bug:
+#   https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY ./tini /sbin/
 COPY ./flux-adapter /usr/local/bin/


### PR DESCRIPTION
Create a minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries